### PR TITLE
Select encoding from parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ### Summary
 
+Modification with add new feature based in [original library project](https://github.com/paypac/DBFFile) develop by [paypac](https://github.com/paypac)
+
 Read and write .dbf (dBase III) files in Node.js:
 
 - Supports `C` (string) , `N` (numeric) , `I` (integer) , `L` (logical) and `D` (date) field types

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Read and write .dbf (dBase III) files in Node.js:
 
 ### Installation
 
-`npm install dbffile`
+`npm install @mugan86/dbffile`
 
 ### Example: reading a .dbf file
 
 ```javascript
-var DBFFile = require('dbffile');
+var DBFFile = require('@mugan86/dbffile');
 
 DBFFile.open('[full path to .dbf file]', '[encoding]')
     .then(dbf => {
@@ -40,7 +40,7 @@ DBFFile.open('[full path to .dbf file]', '[encoding]')
 ### Example: writing a .dbf file
 
 ```javascript
-var DBFFile = require('dbffile');
+var DBFFile = require('@mugan86/dbffile');
 
 var fieldDescriptors = [
     { name: 'fname', type: 'C', size: 255 },

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ### Summary
 
-Modification with add new feature based in [original library project](https://github.com/paypac/DBFFile) develop by [paypac](https://github.com/paypac)
-
 Read and write .dbf (dBase III) files in Node.js:
 
 - Supports `C` (string) , `N` (numeric) , `I` (integer) , `L` (logical) and `D` (date) field types
@@ -20,12 +18,12 @@ Read and write .dbf (dBase III) files in Node.js:
 
 ### Installation
 
-`npm install @mugan86/dbffile`
+`npm install dbffile`
 
 ### Example: reading a .dbf file
 
 ```javascript
-var DBFFile = require('@mugan86/dbffile');
+var DBFFile = require('dbffile');
 
 DBFFile.open('[full path to .dbf file]', '[encoding]')
     .then(dbf => {
@@ -40,7 +38,7 @@ DBFFile.open('[full path to .dbf file]', '[encoding]')
 ### Example: writing a .dbf file
 
 ```javascript
-var DBFFile = require('@mugan86/dbffile');
+var DBFFile = require('dbffile');
 
 var fieldDescriptors = [
     { name: 'fname', type: 'C', size: 255 },

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Read and write .dbf (dBase III) files in Node.js:
 ```javascript
 var DBFFile = require('dbffile');
 
-DBFFile.open('[full path to .dbf file]')
+DBFFile.open('[full path to .dbf file]', '[encoding]')
     .then(dbf => {
         console.log(`DBF file contains ${dbf.recordCount} rows.`);
         console.log(`Field names: ${dbf.fields.map(f => f.name)}`);
@@ -50,7 +50,7 @@ var rows = [
     { fname: 'Mary', lname: 'Smith' }
 ];
 
-DBFFile.create('[full path to .dbf file]', fieldDescriptors)
+DBFFile.create('[full path to .dbf file]', fieldDescriptors, '[encoding]')
     .then(dbf => {
         console.log('DBF file created.');
         return dbf.append(rows);
@@ -86,9 +86,9 @@ class DBFFile {
     fields: { name: string; type: string; size: number; decs: number; }[];
 
     /** Append the specified records to this DBF file. */
-    append(records: any[]): Promise<DBFFile>;
+    append(records: any[], encoding: string): : Promise<DBFFile>;
 
-    /** read some specific rows from the dbf file. **/
-    readRecords(maxRows?: number): Promise<any[]>;
+    /** Read a subset of records from this DBF file. */
+    readRecords(maxRows = 10000000, encoding: string): Promise<any[]>;
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dbffile",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dbffile",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dbffile",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mugan86/dbffile",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "",
   "main": "built/dbf-file.js",
   "typings": "built/dbf-file.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mugan86/dbffile",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "",
   "main": "built/dbf-file.js",
   "typings": "built/dbf-file.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@mugan86/dbffile",
+  "name": "dbffile",
   "version": "0.8.2",
-  "description": "",
+  "description": "DBF files manage library with diferents encodings",
   "main": "built/dbf-file.js",
   "typings": "built/dbf-file.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dbffile",
+  "name": "@mugan86/dbffile",
   "version": "0.7.6",
   "description": "",
   "main": "built/dbf-file.js",
@@ -18,13 +18,21 @@
   "keywords": [
     "dbf",
     "dBase",
-    "dBase III"
+    "dBase III",
+    "encoding select"
   ],
   "author": {
     "name": "Troy Gerwien",
     "email": "yortus@gmail.com",
     "url": "http://github.com/yortus/"
   },
+  "contributors": [
+    {
+      "name": "Anartz Mugika Ledo",
+      "email": "mugan86@gmail.com",
+      "url": "http://github.com/mugan86/"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/paypac/DBFFile/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mugan86/dbffile",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "description": "",
   "main": "built/dbf-file.js",
   "typings": "built/dbf-file.d.ts",

--- a/test/reading-a-dbf-file.ts
+++ b/test/reading-a-dbf-file.ts
@@ -35,8 +35,8 @@ describe('Reading a DBF file', () => {
             let actualDels = null;
             let actualError = null;
             try {
-                let dbf = await (DBFFile.open(filepath));
-                let rows = await (dbf.readRecords(500));
+                let dbf = await (DBFFile.open(filepath, 'latin1'));
+                let rows = await (dbf.readRecords(500, 'latin1'));
                 actualRows = dbf.recordCount;
                 actualData = _.pick(rows[0], _.keys(expectedData));
                 actualDels = dbf.recordCount - rows.length;

--- a/test/writing-a-dbf-file.ts
+++ b/test/writing-a-dbf-file.ts
@@ -5,7 +5,7 @@ import {sync as rimraf} from 'rimraf'
 import {expect} from 'chai';
 import * as DBFFile from 'dbffile';
 
-
+const ENCODING = 'latin1';
 describe('Writing a DBF file', () => {
 
     let tests = [
@@ -33,14 +33,14 @@ describe('Writing a DBF file', () => {
             let srcPath = path.join(__dirname, `./fixtures/${test.filename}`);
             let dstPath = path.join(__dirname, `./fixtures/${test.filename}.out`);
 
-            let srcDbf = await (DBFFile.open(srcPath));
-            let dstDbf = await (DBFFile.create(dstPath, srcDbf.fields.concat(test.addFields)));
+            let srcDbf = await (DBFFile.open(srcPath, ENCODING));
+            let dstDbf = await (DBFFile.create(dstPath, srcDbf.fields.concat(test.addFields), ENCODING));
 
-            let rows = await (srcDbf.readRecords(100));
-            await (dstDbf.append(rows.map(test.addValues)));
+            let rows = await (srcDbf.readRecords(100, ENCODING));
+            await (dstDbf.append(rows.map(test.addValues), ENCODING));
 
-            dstDbf = await (DBFFile.open(dstPath));
-            rows = await (dstDbf.readRecords(500));
+            dstDbf = await (DBFFile.open(dstPath, ENCODING));
+            rows = await (dstDbf.readRecords(500, ENCODING));
             let firstRow = _.pick(rows[0], _.keys(test.firstRow));
             expect(dstDbf.recordCount).equal(test.rowCount);
             expect(firstRow).deep.equal(test.firstRow);


### PR DESCRIPTION
Functionality that serves to manage the dbf files in the encoding that we choose. I was working with a DBF file that I had to work with, and this was in the "latin1" encoding, so characters like "ñ", "ª", ... were not displayed correctly since by default it only reads in utf8. 

Analyzing the library, I saw the possibility of adding it so that we can put it as a parameter due to my needs and I thought of contributing my little bit to this library that has been very useful for me ;)