### PR TITLE
Add option to allow unkown versions or fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ The module exports the `DBFFile` class, which has the following shape:
 class DBFFile {
 
     /** Opens an existing DBF file. */
-    static open(path: string, options?: Options): Promise<DBFFile>;
+    static async open(path: string, options?: Partial<Options>);
 
     /** Creates a new DBF file with no records. */
-    static create(path: string, fields: FieldDescriptor[], options?: Options): Promise<DBFFile>;
+    static async create(path: string, fields: FieldDescriptor[], options?: Partial<Options>);
 
     /** Full path to the DBF file. */
     path: string;
@@ -123,11 +123,26 @@ export interface FieldDescriptor {
     decimalPlaces?: number;
 }
 
+/**
+ * Character encoding. Either a string, which applies to all fields, or an object whose keys are field names and
+ * whose values are encodings. If given as an object, field keys are all optional, but a 'default' key is required.
+ * Valid encodings may be found here: https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
+ */
+type Encoding = string | {default: string, [fieldName: string]: string};
 
 /** Options that may be passed to `DBFFile.open` and `DBFFile.create`. */
 interface Options {
 
-    /** The character encoding(s) to use when reading/writing the DBF file. */
-    encoding?: string | {default: string, [fieldName: string]: string};
+    /** The file version to open or create. Currently versions 0x03, 0x83 and 0x8b are supported. */
+    fileVersion?: FileVersion;
+
+    /** The character encoding(s) to use when reading/writing the DBF file. Defaults to ISO-8859-1. */
+    encoding: Encoding;
+
+    /** Do not fail if trying to parse or write a version that is not officially supported. (This may still fail on other things)  */
+    allowUnkownVersion?: boolean;
+
+    /** Do not fail if trying to parse or write un-supported field types. */
+    allowUnkownFields?: boolean;
 }
 ```

--- a/src/dbf-file.ts
+++ b/src/dbf-file.ts
@@ -504,6 +504,7 @@ async function appendRecordsToDBF(dbf: DBFFile, records: Array<Record<string, un
 
                     default:
                         if (dbf._allowUnkownFields) {
+                            console.log(`Type '${field.type}' is not supported. It will be filled with spaces (ignored by options)`);
                             // fill with spaces
                             for (let k = 0; k < field.size; ++k) {
                                 buffer.writeUInt8(0x20, offset++);

--- a/src/field-descriptor.ts
+++ b/src/field-descriptor.ts
@@ -1,4 +1,5 @@
 import {FileVersion} from './file-version';
+import {Options} from './options';
 
 
 
@@ -25,7 +26,7 @@ export interface FieldDescriptor {
 
 
 
-export function validateFieldDescriptor(version: FileVersion, field: FieldDescriptor): void {
+export function validateFieldDescriptor(version: FileVersion, field: FieldDescriptor, options: Options): void {
     let {name, type, size, decimalPlaces: decs} = field;
 
     // name
@@ -35,7 +36,13 @@ export function validateFieldDescriptor(version: FileVersion, field: FieldDescri
 
     // type
     if (typeof type !== 'string' || type.length !== 1) throw new Error('Type must be a single character');
-    if (FieldTypes.indexOf(type) === -1) throw new Error(`Type '${type}' is not supported`);
+    if (FieldTypes.indexOf(type) === -1) {
+        if (options.allowUnkownFields) {
+            console.log(`Type '${type}' is not supported. (ignored by options)`);
+        } else {
+            throw new Error(`Type '${type}' is not supported.`);
+        }
+    }
 
     // size
     if (typeof size !== 'number') throw new Error('Size must be a number');

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,10 +13,10 @@ export interface Options {
     /** The character encoding(s) to use when reading/writing the DBF file. Defaults to ISO-8859-1. */
     encoding: Encoding;
 
-    /** Do not fail if trying to parse a version that is not officially supported. (This may still fail on other things)  */
+    /** Do not fail if trying to parse or write a version that is not officially supported. (This may still fail on other things)  */
     allowUnkownVersion?: boolean;
 
-    /** Do not fail if trying to parse un-supported field types. */
+    /** Do not fail if trying to parse or write un-supported field types. */
     allowUnkownFields?: boolean;
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -12,6 +12,12 @@ export interface Options {
 
     /** The character encoding(s) to use when reading/writing the DBF file. Defaults to ISO-8859-1. */
     encoding: Encoding;
+
+    /** Do not fail if trying to parse a version that is not officially supported. (This may still fail on other things)  */
+    allowUnkownVersion?: boolean;
+
+    /** Do not fail if trying to parse un-supported field types. */
+    allowUnkownFields?: boolean;
 }
 
 
@@ -48,7 +54,7 @@ export function normaliseOptions(options?: Partial<Options>): Options {
 
     // Return a new options object.
     return {
-        fileVersion: options.fileVersion,
-        encoding
+        ...options,
+        encoding,
     };
 }


### PR DESCRIPTION
I added two new options, so that you can allow un-supported versions or field-types. There is a console information to warn the user that an unsupported field was read / written, but the process itself will not fail if enabled.

## off-topic
I updated the README api section file to match the current types used by this lib.

```ts
/** Options that may be passed to `DBFFile.open` and `DBFFile.create`. */
interface Options {

    /** The file version to open or create. Currently versions 0x03, 0x83 and 0x8b are supported. */
    fileVersion?: FileVersion;

    /** The character encoding(s) to use when reading/writing the DBF file. Defaults to ISO-8859-1. */
    encoding: Encoding;

    /** Do not fail if trying to parse or write a version that is not officially supported. (This may still fail on other things)  */
    allowUnkownVersion?: boolean;

    /** Do not fail if trying to parse or write un-supported field types. */
    allowUnkownFields?: boolean;
}
```