### PR TITLE
Fix Write Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ async function testRead() {
     console.log(`DBF file contains ${dbf.recordCount} records.`);
     console.log(`Field names: ${dbf.fields.map(f => f.name).join(', ')}`);
     let records = await dbf.readRecords(100);
-    for (let record of records) console.log(records);
+    for (let record of records) console.log(record);
 }
 ```
 


### PR DESCRIPTION
The write example loops all records but logs the array instead of each object