### PR TITLE
Add support for 0xF5 FoxPro 2.x (or earlier) with memo

### DIFF
--- a/src/dbf-file.ts
+++ b/src/dbf-file.ts
@@ -109,7 +109,7 @@ async function openDBF(path: string, opts?: OpenOptions): Promise<DBFFile> {
         }
         // Locate FoxPro9 memo file, if any. Version 0x30 may or may not have a memo file.
         // Conventions for memo extensions: .dbf => .fpt | .pjx => .pjt | .scx => .sct | .vcx => .vct | .frx => .frt ...
-        if (fileVersion === 0x30) {
+        if (fileVersion === 0x30 || fileVersion === 0xF5) {
             const dbExt = extname(path).toLowerCase();
             const memoExt = dbExt == '.dbf' ? '.fpt' : `.${dbExt.substr(1,2)}t`;
             for (const ext of [memoExt, memoExt.toUpperCase()]) {

--- a/src/dbf-file.ts
+++ b/src/dbf-file.ts
@@ -435,7 +435,7 @@ async function readRecordsFromDBF(dbf: DBFFile, maxCount: number) {
                                 }
 
                                 // Handle first/next block of FoxPro9 memo data.
-                                else if (dbf._version === 0x30) {
+                                else if (dbf._version === 0x30 || dbf._version === 0xF5) {
                                     // Memo header
                                     // 00 - 03: Next free block
                                     // 04 - 05: Not used

--- a/src/file-version.ts
+++ b/src/file-version.ts
@@ -3,11 +3,12 @@ export type FileVersion =
     | 0x83 // dBase III with memo file
     | 0x8b // dBase IV with memo file
     | 0x30 // Visual FoxPro 9 (may have memo file)
+    | 0xF5 // Visual FoxPro 2.x (earlier version)
 ;
 
 
 
 
 export function isValidFileVersion(fileVersion: number): fileVersion is FileVersion {
-    return [0x03, 0x83, 0x8b, 0x30].includes(fileVersion);
+    return [0x03, 0x83, 0x8b, 0x30, 0xF5].includes(fileVersion);
 }

--- a/test/reading-a-dbf-file.ts
+++ b/test/reading-a-dbf-file.ts
@@ -235,7 +235,7 @@ describe('Reading a DBF file', () => {
                 dbf = await DBFFile.open(filepath, options);
                 records = await dbf.readRecords();
             }
-            catch (err) {
+            catch (err:any) {
                 expect(err.message).contains(expectedError ?? '??????');
                 return;
             }

--- a/test/writing-a-dbf-file.ts
+++ b/test/writing-a-dbf-file.ts
@@ -209,7 +209,7 @@ describe('Writing a DBF file', () => {
                 dstDbf = await DBFFile.open(dstPath, test.options);
                 records = await dstDbf.readRecords(500);
             }
-            catch (err) {
+            catch (err:any) {
                 expect(err.message).equals(expectedError ?? '??????');
                 return;
             }


### PR DESCRIPTION
Hi, I found that this library can read the FoxPro 2.x with memo field database just by simply adding the DBF Version 0xF5. I tested and it works well.