### PR TITLE
feature: add functionality to use alternative file systems

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,9 @@
 	},
 
 	// Specifies the folder path containing the tsserver and lib*.d.ts files to use.
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+
+	// Some bracket preferences as per original code
+	"typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
+	"javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false
 }

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Read and write .dbf (dBase III and Visual FoxPro) files in Node.js:
 ### Example: reading a .dbf file
 
 ```javascript
-import {DBFFile} from 'dbffile';
+import {DBFFile, nodeFileSystem} from 'dbffile';
 
 async function testRead() {
-    let dbf = await DBFFile.open('<full path to .dbf file>');
+    let dbf = await DBFFile.open(nodeFileSystem, '<full path to .dbf file>');
     console.log(`DBF file contains ${dbf.recordCount} records.`);
     console.log(`Field names: ${dbf.fields.map(f => f.name).join(', ')}`);
     let records = await dbf.readRecords(100);
@@ -56,7 +56,7 @@ async function testRead() {
 ### Example: writing a .dbf file
 
 ```javascript
-import {DBFFile} from 'dbffile';
+import {DBFFile, nodeFileSystem} from 'dbffile';
 
 async function testWrite() {
     let fieldDescriptors = [
@@ -69,7 +69,7 @@ async function testWrite() {
         { fname: 'Mary', lname: 'Smith' }
     ];
 
-    let dbf = await DBFFile.create('<full path to .dbf file>', fieldDescriptors);
+    let dbf = await DBFFile.create(nodeFileSystem, '<full path to .dbf file>', fieldDescriptors);
     console.log('DBF file created.');
     await dbf.appendRecords(records);
     console.log(`${records.length} records added.`);
@@ -98,10 +98,10 @@ The module exports the `DBFFile` class, which has the following shape:
 class DBFFile {
 
     /** Opens an existing DBF file. */
-    static open(path: string, options?: OpenOptions): Promise<DBFFile>;
+    static open(fileSystem: FileSystem, path: string, options?: OpenOptions): Promise<DBFFile>;
 
     /** Creates a new DBF file with no records. */
-    static create(path: string, fields: FieldDescriptor[], options?: CreateOptions): Promise<DBFFile>;
+    static create(fileSystem: FileSystem, path: string, fields: FieldDescriptor[], options?: CreateOptions): Promise<DBFFile>;
 
     /** Full path to the DBF file. */
     path: string;
@@ -121,6 +121,28 @@ class DBFFile {
     /** Appends the specified records to this DBF file. */
     appendRecords(records: object[]): Promise<DBFFile>;
 }
+
+/** Represents file system */
+interface FileSystem {
+    /** Opens existing file */
+    open(path: string, flags: string): Promise<number>,
+
+    /** Close file handle */
+    close(fd: number): Promise<void>,
+
+    /** Read data from file into buffer */
+    read(fd: number, buffer: Buffer, offset: number, length: number, position: number): Promise<{bytesRead: number, buffer: Buffer}>,
+
+    /** Write data from buffer to file */
+    write(fd: number, buffer: Buffer, offset: number, length: number, position: number): Promise<{bytesWritten: number, buffer: Buffer}>,
+
+    /** Checks if a file exists */
+    exists(path: string): Promise<boolean>,
+
+    /** Returns file size */
+    fileSize(path: string): Promise<number>
+};
+
 
 /** Metadata describing a single field in a DBF file. */
 interface FieldDescriptor {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export {DBFFile, DBFFile as default, DELETED} from './dbf-file';
+export {DBFFile, DBFFile as default, DELETED, FileSystem} from './dbf-file';
 export {FieldDescriptor} from './field-descriptor';
 export {CreateOptions, OpenOptions} from './options';

--- a/src/node-file-system.ts
+++ b/src/node-file-system.ts
@@ -1,0 +1,30 @@
+import * as fs from 'fs';
+import {promisify} from 'util';
+import {FileSystem} from './dbf-file';
+
+
+
+/** Promisified version of fs.stat. */
+export const stat = promisify(fs.stat);
+
+class Fs implements FileSystem {
+    open = promisify(fs.open)
+    close = promisify(fs.close)
+    read = promisify(fs.read)
+    write = promisify(fs.write)
+    exists = async function (path: string) {
+        try {
+            await stat(path);
+            return true;
+        } catch {
+            return false;
+        }
+
+    }
+    fileSize = async function (path: string) {
+        const stats = await stat(path);
+        return stats.size;
+    }
+}
+
+export default new Fs();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,38 +1,3 @@
-import * as fs from 'fs';
-import {promisify} from 'util';
-
-
-
-
-/** Promisified version of fs.close. */
-export const close = promisify(fs.close);
-
-
-
-
-/** Promisified version of fs.open. */
-export const open = promisify(fs.open);
-
-
-
-
-/** Promisified version of fs.read. */
-export const read = promisify(fs.read);
-
-
-
-
-/** Promisified version of fs.stat. */
-export const stat = promisify(fs.stat);
-
-
-
-
-/** Promisified version of fs.write. */
-export const write = promisify(fs.write);
-
-
-
 
 /** Creates a date with no local timezone offset. `month` and `day` are 1-based. */
 export function createDate(year: number, month: number, day: number): Date {

--- a/test/reading-a-dbf-file.ts
+++ b/test/reading-a-dbf-file.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {DBFFile, OpenOptions, DELETED} from 'dbffile';
 import * as path from 'path';
-
+import nodeFileSystem from 'dbffile/node-file-system';
 
 
 
@@ -232,7 +232,7 @@ describe('Reading a DBF file', () => {
             let dbf: DBFFile;
             let records: Array<Record<string, unknown> & {[DELETED]?: true}>;
             try {
-                dbf = await DBFFile.open(filepath, options);
+                dbf = await DBFFile.open(nodeFileSystem, filepath, options);
                 records = await dbf.readRecords();
             }
             catch (err) {

--- a/test/writing-a-dbf-file.ts
+++ b/test/writing-a-dbf-file.ts
@@ -3,6 +3,7 @@ import {CreateOptions, DBFFile, FieldDescriptor, OpenOptions} from 'dbffile';
 import {promises as fs} from 'fs';
 import * as path from 'path';
 import * as rimraf from 'rimraf'
+import nodeFileSystem from 'dbffile/node-file-system';
 
 
 
@@ -202,11 +203,11 @@ describe('Writing a DBF file', () => {
             let srcPath = path.join(__dirname, `./fixtures/${test.filename}`);
             let dstPath = path.join(__dirname, `./fixtures/${test.filename}.out`);
             try {
-                let srcDbf = await DBFFile.open(srcPath, test.options);
-                dstDbf = await DBFFile.create(dstPath, srcDbf.fields.concat(test.newFields), test.options as any);
+                let srcDbf = await DBFFile.open(nodeFileSystem, srcPath, test.options);
+                dstDbf = await DBFFile.create(nodeFileSystem, dstPath, srcDbf.fields.concat(test.newFields), test.options as any);
                 records = await srcDbf.readRecords(100);
                 await dstDbf.appendRecords(records.map(test.newRecord));
-                dstDbf = await DBFFile.open(dstPath, test.options);
+                dstDbf = await DBFFile.open(nodeFileSystem, dstPath, test.options);
                 records = await dstDbf.readRecords(500);
             }
             catch (err) {


### PR DESCRIPTION
I wanted to use the DBF reader within the browser. By default, the file system is not available in the browser. However, using the browser's file API and FileReader, I've been able to get this working in the browser.

Is this something you would consider to add to your codebase?