### PR TITLE
Add opt-in support for long character fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Read and write .dbf (dBase III, dBase IV, FoxPro and Visual FoxPro) files in Nod
     - read-only (can't create/write DBF files with memo fields)
     - supports dBase III (version 0x83), dBase IV (version 0x8b), VFP9 (version 0x30) and FoxPro 2 (version 0xf5) memo files
 - 'Loose' read mode - tries to read any kind of .dbf file without complaining. Unsupported field types are simply skipped.
+- Opt-in support for FoxPro/Clipper character fields longer than 255 bytes.
 - Can open an existing .dbf file
   - Can access all field descriptors
   - Can access total record count
@@ -90,6 +91,19 @@ async function batchWrite() {
     console.log(`${records.length} records added.`);
 }
 ```
+
+### Long Character Fields
+
+Some FoxPro and Clipper DBF files store character field lengths as unsigned 16-bit values across field descriptor
+bytes 16 and 17. Support for this variant is opt-in:
+
+```javascript
+let dbf = await DBFFile.open('<full path to .dbf file>', {longCharacterFields: 'auto'});
+```
+
+The default is `'off'`, which preserves the standard one-byte character field length interpretation. In `'auto'`
+mode, a 16-bit character field length is selected only when it exactly matches the record length declared in the DBF
+header. Writing character fields larger than 255 bytes is not supported.
 
 ### Loose Read Mode
 
@@ -180,6 +194,12 @@ interface OpenOptions {
      * Deleted records have the property `[DELETED]: true`, using the `DELETED` symbol exported from this library.
      */
     includeDeletedRecords?: boolean;
+
+    /**
+     * Controls support for character field lengths stored across descriptor bytes 16 and 17. Defaults to 'off'.
+     * In 'auto' mode, a 16-bit character field length is used only when it matches the declared record length.
+     */
+    longCharacterFields?: 'off' | 'auto';
 }
 
 /** Options that may be passed to `DBFFile.create`. */

--- a/src/dbf-file.ts
+++ b/src/dbf-file.ts
@@ -158,7 +158,8 @@ async function openDBF(path: string, opts?: OpenOptions): Promise<DBFFile> {
             ? {...field, size: field.size + field.decimalPlaces * 256, decimalPlaces: 0}
             : field);
         const longCharacterRecordLength = calculateRecordLengthInBytes(fieldsWithLongCharacterSizes);
-        const hasLongCharacterFields = recordLength !== standardRecordLength
+        const hasLongCharacterFields = options.longCharacterFields === 'auto'
+            && recordLength !== standardRecordLength
             && recordLength === longCharacterRecordLength;
         if (hasLongCharacterFields) fields = fieldsWithLongCharacterSizes;
 

--- a/src/dbf-file.ts
+++ b/src/dbf-file.ts
@@ -98,7 +98,7 @@ async function openDBF(path: string, opts?: OpenOptions): Promise<DBFFile> {
         const dateOfLastUpdate = createDate(lastUpdateY + 1900, lastUpdateM, lastUpdateD);
         let recordCount = buffer.readInt32LE(4);
         let headerLength = buffer.readInt16LE(8);
-        let recordLength = buffer.readInt16LE(10);
+        let recordLength = buffer.readUInt16LE(10);
         let memoPath: string | undefined;
 
         // Validate the file version. Skip validation if reading in 'loose' mode.
@@ -132,7 +132,7 @@ async function openDBF(path: string, opts?: OpenOptions): Promise<DBFFile> {
             }
         }
 
-        // Parse and validate all field descriptors. Skip validation if reading in 'loose' mode.
+        // Parse all field descriptors. Validate them after resolving the record layout.
         let fields: FieldDescriptor[] = [];
         const encoding = getEncoding(options.encoding);
         while (headerLength > 32 + fields.length * 32) {
@@ -144,16 +144,32 @@ async function openDBF(path: string, opts?: OpenOptions): Promise<DBFFile> {
                 size: buffer.readUInt8(0x10),
                 decimalPlaces: buffer.readUInt8(0x11)
             };
-            if (options.readMode !== 'loose') {
-                validateFieldDescriptor(field, fileVersion);
-                assert(fields.every(f => f.name !== field.name), `Duplicate field name: '${field.name}'`);
-            }
             fields.push(field);
         }
 
         // Parse the header terminator.
         await read(fd, buffer, 0, 1, 32 + fields.length * 32);
         assert(buffer[0] === 0x0d, 'Invalid DBF: Expected header terminator');
+
+        // FoxPro and Clipper can store character field lengths as an unsigned 16-bit value across descriptor bytes
+        // 16 and 17. Use that interpretation only when it exactly matches the record length declared in the header.
+        const standardRecordLength = calculateRecordLengthInBytes(fields);
+        const fieldsWithLongCharacterSizes = fields.map(field => field.type === 'C' && field.decimalPlaces
+            ? {...field, size: field.size + field.decimalPlaces * 256, decimalPlaces: 0}
+            : field);
+        const longCharacterRecordLength = calculateRecordLengthInBytes(fieldsWithLongCharacterSizes);
+        const hasLongCharacterFields = recordLength !== standardRecordLength
+            && recordLength === longCharacterRecordLength;
+        if (hasLongCharacterFields) fields = fieldsWithLongCharacterSizes;
+
+        // Validate all resolved field descriptors. Skip validation if reading in 'loose' mode.
+        if (options.readMode !== 'loose') {
+            for (let i = 0; i < fields.length; ++i) {
+                const field = fields[i];
+                validateFieldDescriptor(field, fileVersion, hasLongCharacterFields ? 0xffff : 0xff);
+                assert(fields.slice(0, i).every(f => f.name !== field.name), `Duplicate field name: '${field.name}'`);
+            }
+        }
 
         // Validate the record length.
         const computedRecordLength = calculateRecordLengthInBytes(fields);

--- a/src/field-descriptor.ts
+++ b/src/field-descriptor.ts
@@ -20,7 +20,11 @@ export interface FieldDescriptor {
 
 
 
-export function validateFieldDescriptor(field: FieldDescriptor, fileVersion: number): void {
+export function validateFieldDescriptor(
+    field: FieldDescriptor,
+    fileVersion: number,
+    maximumCharacterFieldSize = 255
+): void {
     let {name, type, size, decimalPlaces: decs} = field;
 
     // name
@@ -36,7 +40,9 @@ export function validateFieldDescriptor(field: FieldDescriptor, fileVersion: num
     const memoSize = fileVersion == 0x30 ? 4 : 10;
     if (typeof size !== 'number') throw new Error('Size must be a number');
     if (size < 1) throw new Error('Field size is too small (minimum is 1)');
-    if (type === 'C' && size > 255) throw new Error('Field size is too large (maximum is 255)');
+    if (type === 'C' && size > maximumCharacterFieldSize) {
+        throw new Error(`Field size is too large (maximum is ${maximumCharacterFieldSize})`);
+    }
     if (type === 'N' && size > 20) throw new Error('Field size is too large (maximum is 20)');
     if (type === 'F' && size > 20) throw new Error('Field size is too large (maximum is 20)');
     if (type === 'Y' && size !== 8) throw new Error('Invalid field size (must be 8)');

--- a/src/options.ts
+++ b/src/options.ts
@@ -23,6 +23,13 @@ export interface OpenOptions {
 
     /** Indicates whether deleted records should be included in results when reading records. Defaults to false. */
     includeDeletedRecords?: boolean;
+
+    /**
+     * Controls support for character field lengths stored across descriptor bytes 16 and 17. Defaults to 'off'.
+     * - 'off': preserve the standard one-byte character field length interpretation.
+     * - 'auto': use a 16-bit character field length only when it exactly matches the declared record length.
+     */
+    longCharacterFields?: 'off' | 'auto';
 }
 
 
@@ -70,8 +77,14 @@ export function normaliseOpenOptions(options: OpenOptions | undefined): Required
         throw new Error(`Invalid value 'includeDeletedRecords' value ${includeDeletedRecords}`);
     }
 
+    // Validate `longCharacterFields`.
+    let longCharacterFields = options?.longCharacterFields ?? 'off';
+    if (longCharacterFields !== 'off' && longCharacterFields !== 'auto') {
+        throw new Error(`Invalid long character fields mode ${longCharacterFields}`);
+    }
+
     // Return a new normalised options object.
-    return {encoding, readMode, includeDeletedRecords};
+    return {encoding, readMode, includeDeletedRecords, longCharacterFields};
 }
 
 

--- a/test/reading-long-character-fields.ts
+++ b/test/reading-long-character-fields.ts
@@ -24,7 +24,16 @@ describe('Reading long character fields', () => {
             ],
         });
 
-        const dbf = await DBFFile.open(fixturePath);
+        let defaultError: Error | undefined;
+        try {
+            await DBFFile.open(fixturePath);
+        }
+        catch (err) {
+            defaultError = err;
+        }
+        expect(defaultError?.message).equals('Invalid DBF: Incorrect record length');
+
+        const dbf = await DBFFile.open(fixturePath, {longCharacterFields: 'auto'});
         const records = await dbf.readRecords(10);
 
         expect(dbf.fields).deep.equals([
@@ -36,7 +45,7 @@ describe('Reading long character fields', () => {
             {LONG_TEXT: 'second long character field', COUNT: 22},
         ]);
 
-        const looseDbf = await DBFFile.open(fixturePath, {readMode: 'loose'});
+        const looseDbf = await DBFFile.open(fixturePath, {readMode: 'loose', longCharacterFields: 'auto'});
         expect(await looseDbf.readRecords(10)).deep.equals(records);
     });
 
@@ -47,7 +56,7 @@ describe('Reading long character fields', () => {
             records: [{text: 'standard character field', count: 33}],
         });
 
-        const dbf = await DBFFile.open(fixturePath);
+        const dbf = await DBFFile.open(fixturePath, {longCharacterFields: 'auto'});
         const records = await dbf.readRecords(10);
 
         expect(dbf.fields[0]).deep.equals({name: 'LONG_TEXT', type: 'C', size: 40, decimalPlaces: 1});
@@ -64,7 +73,7 @@ describe('Reading long character fields', () => {
 
         let error: Error | undefined;
         try {
-            await DBFFile.open(fixturePath);
+            await DBFFile.open(fixturePath, {longCharacterFields: 'auto'});
         }
         catch (err) {
             error = err;
@@ -79,7 +88,7 @@ describe('Reading long character fields', () => {
             records: [],
         });
 
-        const dbf = await DBFFile.open(fixturePath);
+        const dbf = await DBFFile.open(fixturePath, {longCharacterFields: 'auto'});
 
         expect(dbf.fields[0]).deep.equals({name: 'LONG_TEXT', type: 'C', size: 40_000, decimalPlaces: 0});
     });
@@ -96,6 +105,22 @@ describe('Reading long character fields', () => {
 
         expect(error?.message).equals('Field size is too large (maximum is 255)');
         expect(fs.existsSync(fixturePath)).equals(false);
+    });
+
+    it('rejects an invalid long character field mode', async () => {
+        const fixturePath = createSyntheticDBF({
+            characterFieldSize: 40,
+            records: [],
+        });
+        let error: Error | undefined;
+        try {
+            await DBFFile.open(fixturePath, {longCharacterFields: 'always'} as any);
+        }
+        catch (err) {
+            error = err;
+        }
+
+        expect(error?.message).equals('Invalid long character fields mode always');
     });
 
     interface SyntheticDBFOptions {

--- a/test/reading-long-character-fields.ts
+++ b/test/reading-long-character-fields.ts
@@ -1,0 +1,156 @@
+import {expect} from 'chai';
+import {DBFFile} from 'dbffile';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+
+
+
+describe('Reading long character fields', () => {
+    let fixturePaths: string[] = [];
+
+    afterEach(() => {
+        for (const fixturePath of fixturePaths) fs.unlinkSync(fixturePath);
+        fixturePaths = [];
+    });
+
+    it('reads character field lengths stored across descriptor bytes 16 and 17', async () => {
+        const fixturePath = createSyntheticDBF({
+            characterFieldSize: 300,
+            records: [
+                {text: 'first long character field', count: 11},
+                {text: 'second long character field', count: 22},
+            ],
+        });
+
+        const dbf = await DBFFile.open(fixturePath);
+        const records = await dbf.readRecords(10);
+
+        expect(dbf.fields).deep.equals([
+            {name: 'LONG_TEXT', type: 'C', size: 300, decimalPlaces: 0},
+            {name: 'COUNT', type: 'N', size: 5, decimalPlaces: 0},
+        ]);
+        expect(records).deep.equals([
+            {LONG_TEXT: 'first long character field', COUNT: 11},
+            {LONG_TEXT: 'second long character field', COUNT: 22},
+        ]);
+
+        const looseDbf = await DBFFile.open(fixturePath, {readMode: 'loose'});
+        expect(await looseDbf.readRecords(10)).deep.equals(records);
+    });
+
+    it('keeps the one-byte character length when it matches the record header', async () => {
+        const fixturePath = createSyntheticDBF({
+            characterFieldSize: 40,
+            characterFieldHighByte: 1,
+            records: [{text: 'standard character field', count: 33}],
+        });
+
+        const dbf = await DBFFile.open(fixturePath);
+        const records = await dbf.readRecords(10);
+
+        expect(dbf.fields[0]).deep.equals({name: 'LONG_TEXT', type: 'C', size: 40, decimalPlaces: 1});
+        expect(records).deep.equals([{LONG_TEXT: 'standard character field', COUNT: 33}]);
+    });
+
+    it('rejects a record length that matches neither interpretation', async () => {
+        const fixturePath = createSyntheticDBF({
+            characterFieldSize: 40,
+            characterFieldHighByte: 1,
+            declaredRecordLength: 47,
+            records: [{text: 'invalid layout', count: 44}],
+        });
+
+        let error: Error | undefined;
+        try {
+            await DBFFile.open(fixturePath);
+        }
+        catch (err) {
+            error = err;
+        }
+
+        expect(error?.message).equals('Invalid DBF: Incorrect record length');
+    });
+
+    it('supports unsigned record lengths', async () => {
+        const fixturePath = createSyntheticDBF({
+            characterFieldSize: 40_000,
+            records: [],
+        });
+
+        const dbf = await DBFFile.open(fixturePath);
+
+        expect(dbf.fields[0]).deep.equals({name: 'LONG_TEXT', type: 'C', size: 40_000, decimalPlaces: 0});
+    });
+
+    it('keeps long character fields read-only', async () => {
+        const fixturePath = path.join(os.tmpdir(), `dbffile-long-character-create-${process.pid}.dbf`);
+        let error: Error | undefined;
+        try {
+            await DBFFile.create(fixturePath, [{name: 'LONG_TEXT', type: 'C', size: 300}]);
+        }
+        catch (err) {
+            error = err;
+        }
+
+        expect(error?.message).equals('Field size is too large (maximum is 255)');
+        expect(fs.existsSync(fixturePath)).equals(false);
+    });
+
+    interface SyntheticDBFOptions {
+        characterFieldSize: number;
+        characterFieldHighByte?: number;
+        declaredRecordLength?: number;
+        records: Array<{text: string, count: number}>;
+    }
+
+    function createSyntheticDBF(options: SyntheticDBFOptions): string {
+        const headerLength = 32 + 2 * 32 + 1;
+        const actualRecordLength = 1 + options.characterFieldSize + 5;
+        const declaredRecordLength = options.declaredRecordLength ?? actualRecordLength;
+        const buffer = Buffer.alloc(headerLength + options.records.length * actualRecordLength + 1, 0x20);
+
+        buffer.fill(0, 0, headerLength);
+        buffer.writeUInt8(0x03, 0);                            // dBASE III without memo
+        buffer.writeUInt8(124, 1);                             // 2024-01-02
+        buffer.writeUInt8(1, 2);
+        buffer.writeUInt8(2, 3);
+        buffer.writeUInt32LE(options.records.length, 4);
+        buffer.writeUInt16LE(headerLength, 8);
+        buffer.writeUInt16LE(declaredRecordLength, 10);
+
+        writeFieldDescriptor(buffer, 32, 'LONG_TEXT', 'C', options.characterFieldSize & 0xff,
+            options.characterFieldHighByte ?? options.characterFieldSize >> 8);
+        writeFieldDescriptor(buffer, 64, 'COUNT', 'N', 5, 0);
+        buffer.writeUInt8(0x0d, 96);
+
+        for (let index = 0; index < options.records.length; ++index) {
+            const record = options.records[index];
+            const offset = headerLength + index * actualRecordLength;
+            buffer.writeUInt8(0x20, offset);
+            buffer.write(record.text, offset + 1, options.characterFieldSize, 'latin1');
+            buffer.write(String(record.count).padStart(5, ' '), offset + 1 + options.characterFieldSize, 5, 'ascii');
+        }
+        buffer.writeUInt8(0x1a, buffer.length - 1);
+
+        const fixturePath = path.join(os.tmpdir(), `dbffile-long-character-${process.pid}-${fixturePaths.length}.dbf`);
+        fs.writeFileSync(fixturePath, buffer);
+        fixturePaths.push(fixturePath);
+        return fixturePath;
+    }
+
+    function writeFieldDescriptor(
+        buffer: Buffer,
+        offset: number,
+        name: string,
+        type: string,
+        sizeLowByte: number,
+        sizeHighByte: number
+    ): void {
+        buffer.write(name, offset, 10, 'ascii');
+        buffer.write(type, offset + 11, 1, 'ascii');
+        buffer.writeUInt8(sizeLowByte, offset + 16);
+        buffer.writeUInt8(sizeHighByte, offset + 17);
+    }
+});


### PR DESCRIPTION
## Summary

- add opt-in support for FoxPro/Clipper character fields whose length is stored as an unsigned 16-bit value across field descriptor bytes 16 and 17
- introduce `longCharacterFields: 'off' | 'auto'`, defaulting to `'off'` for backward compatibility
- in `'auto'` mode, select the extended interpretation only when it exactly matches the record length declared in the DBF header
- read the header record length as unsigned while keeping creation of character fields larger than 255 bytes disabled
- document the option, behavior, and limitations in the README and API reference

## Root cause

The reader currently always treats byte 16 as the complete character field size and byte 17 as the decimal count. For DBF variants that use byte 17 as the high byte of a character field length, this produces a smaller computed record size and fails with `Invalid DBF: Incorrect record length`.

The new behavior is disabled by default. When a caller explicitly passes `{longCharacterFields: 'auto'}`, detection first calculates the existing one-byte layout. It only uses 16-bit character sizes when the existing layout does not match and the extended layout exactly reconciles with the declared record length. Files whose one-byte layout already matches retain the current behavior.

This is a follow-up to #80 and the earlier approach in #81.

## Validation

- added runtime-generated synthetic DBF cases for a 300-byte character field with multiple records
- verified that the default `'off'` mode preserves the previous failure behavior
- covered strict and loose read modes
- covered fallback to the existing one-byte interpretation
- covered rejection when neither layout matches
- covered unsigned record lengths above 32767
- verified that writing character fields larger than 255 bytes remains rejected
- covered validation of unsupported `longCharacterFields` values
- `npm test` passes on Node.js 12 and Node.js 18: 60 passing

All new fixtures are generated from synthetic values during the test run; no external DBF files or data are included.
